### PR TITLE
refactor: generic UniqueId component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2480,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2637,7 @@ dependencies = [
  "mime",
  "rmp-serde",
  "serde",
+ "serde_cbor",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",

--- a/game/src/ecs/features/common/components/uuid.rs
+++ b/game/src/ecs/features/common/components/uuid.rs
@@ -41,10 +41,10 @@ where
 
 impl<T> std::fmt::Debug for UniqueId<T>
 where
-    T: UniqueIdType + std::fmt::Debug,
+    T: UniqueIdType,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple(short_type_name::<T>())
+        f.debug_tuple(format!("UniqueId<{}>", short_type_name::<T>()).as_str())
             .field(&self.inner)
             .finish()
     }

--- a/game/src/ecs/features/common/components/uuid.rs
+++ b/game/src/ecs/features/common/components/uuid.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 
 use bevy::{prelude::*, utils::Uuid};
 
+use crate::utils::short_type_name;
+
 pub trait UniqueIdType: Send + Sync + 'static {}
 
 #[derive(Component, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -42,8 +44,8 @@ where
     T: UniqueIdType + std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("UniqueId<Droid>")
-            .field(&self.inner.to_string())
+        f.debug_tuple(short_type_name::<T>())
+            .field(&self.inner)
             .finish()
     }
 }

--- a/game/src/ecs/features/common/components/uuid.rs
+++ b/game/src/ecs/features/common/components/uuid.rs
@@ -1,10 +1,58 @@
+use std::marker::PhantomData;
+
 use bevy::{prelude::*, utils::Uuid};
 
-#[derive(Component, Deref)]
-pub struct UniqueId(pub Uuid);
+pub trait UniqueIdType: Send + Sync + 'static {}
 
-impl UniqueId {
-    pub(crate) fn new_random() -> UniqueId {
-        UniqueId(Uuid::new_v4())
+#[derive(Component, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UniqueId<T: UniqueIdType> {
+    phantom: PhantomData<T>,
+
+    pub(crate) inner: Uuid,
+}
+
+impl<T> UniqueId<T>
+where
+    T: UniqueIdType,
+{
+    pub(crate) fn new_random() -> UniqueId<T> {
+        UniqueId {
+            phantom: PhantomData,
+
+            inner: Uuid::new_v4(),
+        }
+    }
+
+    pub fn into_inner(self) -> Uuid {
+        self.inner
+    }
+}
+
+impl<T> AsRef<Uuid> for UniqueId<T>
+where
+    T: UniqueIdType,
+{
+    fn as_ref(&self) -> &Uuid {
+        &self.inner
+    }
+}
+
+impl<T> std::fmt::Debug for UniqueId<T>
+where
+    T: UniqueIdType + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("UniqueId<Droid>")
+            .field(&self.inner.to_string())
+            .finish()
+    }
+}
+
+impl<T> std::fmt::Display for UniqueId<T>
+where
+    T: UniqueIdType,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.inner.to_string())
     }
 }

--- a/game/src/ecs/features/common/components/uuid.rs
+++ b/game/src/ecs/features/common/components/uuid.rs
@@ -8,7 +8,7 @@ pub trait UniqueIdType: Send + Sync + 'static {}
 pub struct UniqueId<T: UniqueIdType> {
     phantom: PhantomData<T>,
 
-    pub(crate) inner: Uuid,
+    inner: Uuid,
 }
 
 impl<T> UniqueId<T>

--- a/game/src/ecs/features/droids/components/droid.rs
+++ b/game/src/ecs/features/droids/components/droid.rs
@@ -1,14 +1,17 @@
 use bevy::prelude::*;
 
-use crate::ecs::features::{common::UniqueId, movement::Speed};
+use crate::ecs::features::{
+    common::{UniqueId, UniqueIdType},
+    movement::Speed,
+};
 
-#[derive(Component)]
 pub struct Droid;
+
+impl UniqueIdType for Droid {}
 
 #[derive(Bundle)]
 pub struct DroidBundle {
-    pub droid: Droid,
-    pub uuid: UniqueId,
+    pub id: UniqueId<Droid>,
     pub name: Name,
     pub speed: Speed,
     pub position: Transform,
@@ -17,8 +20,7 @@ pub struct DroidBundle {
 impl Default for DroidBundle {
     fn default() -> Self {
         Self {
-            droid: Droid,
-            uuid: UniqueId::new_random(),
+            id: UniqueId::new_random(),
             name: Name::new("Droid".to_string()),
             speed: Speed::per_second(1.0),
             position: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),

--- a/game/src/ecs/features/droids/components/droid.rs
+++ b/game/src/ecs/features/droids/components/droid.rs
@@ -21,7 +21,7 @@ impl Default for DroidBundle {
     fn default() -> Self {
         Self {
             id: UniqueId::new_random(),
-            name: Name::new("Droid".to_string()),
+            name: Name::new("Droid"),
             speed: Speed::per_second(1.0),
             position: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
         }

--- a/game/src/ecs/features/energy/systems/attach_energy.rs
+++ b/game/src/ecs/features/energy/systems/attach_energy.rs
@@ -1,6 +1,7 @@
 use bevy::{log, prelude::*};
 
 use crate::ecs::features::{
+    common::UniqueId,
     energy::{components::EnergyRegeneration, Energy},
     players::Player,
 };
@@ -8,7 +9,7 @@ use crate::ecs::features::{
 pub fn attach_player_energy(
     mut commands: Commands,
     time: Res<Time>,
-    query: Query<Entity, Added<Player>>,
+    query: Query<Entity, Added<UniqueId<Player>>>,
 ) {
     for entity in query.iter() {
         log::info!("attaching energy components to entity: {:?}", entity);

--- a/game/src/ecs/features/movement/socket_events/movement_changed_socket_event.rs
+++ b/game/src/ecs/features/movement/socket_events/movement_changed_socket_event.rs
@@ -1,3 +1,4 @@
+use bevy::utils::Uuid;
 use serde::Serialize;
 use st_commander::event::SocketEvent;
 use utoipa::ToSchema;
@@ -7,7 +8,7 @@ use crate::ecs::features::tick::Tick;
 #[derive(Debug, Serialize, ToSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PositionWithEta {
-    pub uuid: String,
+    pub uuid: Uuid,
     pub origin: (f32, f32),
     pub destination: (f32, f32),
     pub current_tick: Tick,

--- a/game/src/ecs/features/movement/systems/sync_movement.rs
+++ b/game/src/ecs/features/movement/systems/sync_movement.rs
@@ -1,20 +1,23 @@
-use bevy::{log, prelude::*};
+use bevy::prelude::*;
 use st_commander::connections::SocketConnections;
 
-use crate::ecs::features::movement::{
-    components::Immobile,
-    socket_events::{MovementChangedSocketEvent, PositionWithEta},
-    Distance,
-};
 use crate::ecs::features::tick::TickTimer;
 use crate::ecs::features::{
     common::UniqueId,
     movement::{Destination, Speed},
 };
+use crate::ecs::features::{
+    droids::Droid,
+    movement::{
+        components::Immobile,
+        socket_events::{MovementChangedSocketEvent, PositionWithEta},
+        Distance,
+    },
+};
 
 pub fn sync_entity_movement(
     query: Query<
-        (&UniqueId, &Speed, &Destination, &Transform),
+        (&UniqueId<Droid>, &Speed, &Destination, &Transform),
         (With<Destination>, Without<Immobile>),
     >,
     tick: Res<TickTimer>,
@@ -22,14 +25,14 @@ pub fn sync_entity_movement(
 ) {
     let mut droid_positions = Vec::new();
 
-    for (uuid, speed, destination, transform) in query.iter() {
+    for (id, speed, destination, transform) in query.iter() {
         let distance = Distance::between_positions(transform.translation, destination.0);
         let remaining_ticks = distance / *speed;
         let current_tick = tick.current_tick();
         let arrival_tick = current_tick + remaining_ticks;
 
         let position = PositionWithEta {
-            uuid: uuid.0.to_string(),
+            uuid: *id.as_ref(),
             origin: (transform.translation.x, transform.translation.y),
             destination: (destination.x, destination.y),
             current_tick,

--- a/game/src/ecs/features/players/components/player.rs
+++ b/game/src/ecs/features/players/components/player.rs
@@ -1,4 +1,5 @@
-use bevy::prelude::*;
+use crate::ecs::features::common::UniqueIdType;
 
-#[derive(Component)]
 pub struct Player;
+
+impl UniqueIdType for Player {}

--- a/game/src/ecs/features/players/systems/update_connected_players.rs
+++ b/game/src/ecs/features/players/systems/update_connected_players.rs
@@ -17,8 +17,8 @@ use crate::ecs::features::{
 #[derive(Bundle)]
 struct PlayerBundle {
     connection_id: ConnectionId,
-    player: Player,
-    uuid: UniqueId,
+
+    id: UniqueId<Player>,
     name: Name,
 }
 
@@ -30,15 +30,15 @@ pub fn update_connected_players(
     for event in event_reader.read() {
         match event {
             SocketConnectionEvent::Connected { connection } => {
-                let uuid = UniqueId::new_random();
+                let id = UniqueId::new_random();
 
-                let name = Name::new(format!("player-{}", &uuid.to_string()[..8]));
+                let name = Name::new(format!("player-{}", &id));
 
                 // If the player entity exists before they connect, find the entity and attach them here
                 let entity = commands.spawn(PlayerBundle {
                     connection_id: connection.id,
-                    player: Player,
-                    uuid,
+
+                    id,
                     name,
                 });
 

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -3,6 +3,7 @@
 use bevy::{log::LogPlugin, prelude::*};
 
 mod ecs;
+mod utils;
 
 use ecs::features::FeaturesPlugin;
 use st_commander::CommanderPlugin;

--- a/game/src/utils/mod.rs
+++ b/game/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod short_type_name;
+
+pub use short_type_name::short_type_name;

--- a/game/src/utils/short_type_name.rs
+++ b/game/src/utils/short_type_name.rs
@@ -1,0 +1,11 @@
+pub fn short_type_name<T>() -> &'static str {
+    let type_name = std::any::type_name::<T>();
+
+    type_name
+        .split('<')
+        .next()
+        .unwrap_or(type_name)
+        .split("::")
+        .last()
+        .unwrap_or(type_name)
+}


### PR DESCRIPTION
Allows `UniqueId<Droid>` as a single component instead of relying on both `UniqueId` and a `Droid` marker trait. While this means we cannot _easily_ iterate over absolutely everything with a `UniqueId`, I don't think it would be prudent to do that in the first place, so.